### PR TITLE
Fix: Modal z-index

### DIFF
--- a/style.css
+++ b/style.css
@@ -267,7 +267,7 @@ body {
 .modal {
     display: none;
     position: fixed;
-    z-index: 1;
+    z-index: 20;
     left: 0;
     top: 0;
     width: 100%;


### PR DESCRIPTION
The Gemini Key Enter modal was hiding behind the chat window. This was because the modal's z-index was lower than the chat window's z-index. This commit increases the modal's z-index to ensure it appears on top of all other elements.